### PR TITLE
fix: correct test configuration for GitHub Actions

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,12 +1,12 @@
 return {
   _all = {
-    root = "./test",
-    pattern = ".*_spec.lua$",
-    lpath = "./?.lua;./lua/?.lua;./lua/?/init.lua",
+    root = ".",
+    pattern = "_spec%.lua$",
+    helper = "test/init.lua",
+    lpath = "./lua/?.lua;./lua/?/init.lua",
+    verbose = true
   },
   default = {
-    verbose = true,
-    coverage = false,
-    helper = "init.lua"
+    helper = "test/init.lua"
   }
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,14 @@ jobs:
           luarocks install busted
           luarocks install luacov
           luarocks install luacov-coveralls
+          luarocks install luafilesystem
 
       - name: Run Tests
+        env:
+          LUA_PATH: "./lua/?.lua;./lua/?/init.lua;./?.lua;$LUA_PATH"
+          GITPILOT_TEST: "1"
         run: |
-          busted --coverage --helper=test/init.lua
+          busted -v --coverage test/gitpilot/features/
 
       - name: Upload coverage to Coveralls
         env:


### PR DESCRIPTION
- Update .busted configuration with correct paths
- Add luafilesystem dependency
- Configure LUA_PATH in GitHub Actions
- Set GITPILOT_TEST environment variable