### PR TITLE
ci: Disable cache for Lua setup to fix installation error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       uses: leafo/gh-actions-lua@v9
       with:
         luaVersion: "5.1"
+        cache: false
 
     - name: Setup Luarocks
       uses: leafo/gh-actions-luarocks@v4


### PR DESCRIPTION
The GitHub Actions workflow was failing to install Lua 5.1 due to a `400 Bad Request` error from the cache service. This error is likely caused by a corrupted or problematic cache.

This commit disables the cache for the `leafo/gh-actions-lua@v9` action by setting `cache: false`. This will force the workflow to build Lua from scratch on each run, which will be slightly slower but should resolve the installation failure and allow the test suite to run.