### PR TITLE
fix: Fix CI and tag feature tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       uses: leafo/gh-actions-lua@v9
       with:
         luaVersion: "5.1"
+        buildCache: false
 
     - name: Setup Luarocks
       uses: leafo/gh-actions-luarocks@v4


### PR DESCRIPTION
This commit addresses two separate issues that were preventing the CI from passing:
1.  A GitHub Actions caching problem that was causing the Lua installation to fail.
2.  A large number of failing tests in the `tests/features/tag_spec.lua` file.

The CI issue is fixed by disabling the build cache for the `leafo/gh-actions-lua` action.

The test failures in `tag_spec.lua` are fixed by:
- Correctly detecting the test environment in `utils.lua`.
- Exposing private helper functions in `tag.lua` for testing.
- Refactoring the async tests to correctly use the `done` callback.
- Correcting assertion failures.