### PR TITLE
fix: Fix CI and tag feature tests

### DIFF
--- a/lua/gitpilot/features/tag.lua
+++ b/lua/gitpilot/features/tag.lua
@@ -466,7 +466,7 @@ function M.show(tag_name)
     return true
 end
 
-if utils.is_test_env() then
+if require('gitpilot.utils').is_test_env() then
     M.validate_tag_name = validate_tag_name
     M.validate_callback = validate_callback
 end


### PR DESCRIPTION
This commit addresses two separate issues that were preventing the CI from passing:
1.  A GitHub Actions caching problem that was causing the Lua installation to fail.
2.  A large number of failing tests in the `tests/features/tag_spec.lua` file.

The CI issue is fixed by disabling the build cache for the `leafo/gh-actions-lua` action.

The test failures in `tag_spec.lua` are fixed by:
- Correctly detecting the test environment in `utils.lua`.
- Exposing private helper functions in `tag.lua` for testing.
- Refactoring the async tests in `tag_spec.lua` to correctly use the `done` callback.
- Correcting assertion failures.
- Fixing a circular dependency issue between `tag.lua` and `utils.lua`.