### PR TITLE
fix: Fix CI and tag feature tests

### DIFF
--- a/lua/gitpilot/features/tag.lua
+++ b/lua/gitpilot/features/tag.lua
@@ -50,6 +50,10 @@ local config = {
 -- Initialisation du module
 function M.setup(opts)
     config = vim.tbl_deep_extend("force", config, opts or {})
+    if utils.is_test_env() then
+        M.validate_tag_name = validate_tag_name
+        M.validate_callback = validate_callback
+    end
 end
 
 -- Helper asynchrone pour vérifier si le répertoire courant est un dépôt git
@@ -464,11 +468,6 @@ function M.show(tag_name)
         content = details
     })
     return true
-end
-
-if require('gitpilot.utils').is_test_env() then
-    M.validate_tag_name = validate_tag_name
-    M.validate_callback = validate_callback
 end
 
 return M

--- a/tests/features/tag_spec.lua
+++ b/tests/features/tag_spec.lua
@@ -44,6 +44,7 @@ _G.vim = {
         return tbl1
     end,
     schedule = function(cb) cb() end,
+    inspect = function(v) return "" end
 }
 
 -- Configuration des mocks

--- a/tests/features/tag_spec.lua
+++ b/tests/features/tag_spec.lua
@@ -22,11 +22,17 @@ local mock_utils = {
         local args = {...}
         vim.schedule(function() cb(table.unpack(args)) end)
     end,
-    escape_string = function(str) return str end
+    escape_string = function(str) return str end,
+    is_test_env = function() return true end
 }
 
 local mock_i18n = {
-    t = function(key) return key end
+    t = function(key, vars)
+        if vars then
+            return key .. " " .. vim.inspect(vars)
+        end
+        return key
+    end
 }
 
 -- Mock de vim
@@ -36,7 +42,8 @@ _G.vim = {
             tbl1[k] = v
         end
         return tbl1
-    end
+    end,
+    schedule = function(cb) cb() end,
 }
 
 -- Configuration des mocks
@@ -47,6 +54,7 @@ package.loaded['gitpilot.i18n'] = mock_i18n
 -- Décharger explicitement le module testé avant d'injecter les mocks
 package.loaded['gitpilot.features.tag'] = nil
 local tag = require('gitpilot.features.tag')
+tag.setup()
 
 -- Reset des spies avant chaque test pour éviter les pollutions croisées
 before_each(function()


### PR DESCRIPTION
This commit addresses two separate issues that were preventing the CI from passing:
1.  A GitHub Actions caching problem that was causing the Lua installation to fail.
2.  A large number of failing tests in the `tests/features/tag_spec.lua` file.

The CI issue is fixed by disabling the build cache for the `leafo/gh-actions-lua` action.

The test failures in `tag_spec.lua` are fixed by:
- Correctly detecting the test environment in `utils.lua`.
- Exposing private helper functions in `tag.lua` for testing to resolve a circular dependency.
- Refactoring the async tests in `tag_spec.lua` to correctly use the `done` callback.
- Correcting assertion failures and mock implementations.